### PR TITLE
TECH-524: Add cucumber test for POST /send/email/single

### DIFF
--- a/examples/mock/mockoon-messaging.json
+++ b/examples/mock/mockoon-messaging.json
@@ -67,16 +67,16 @@
     {
       "uuid": "3abd79d9-8f58-4cb3-9c68-523fa60764bc",
       "type": "http",
-      "documentation": "",
-      "method": "get",
+      "documentation": "Send a single email",
+      "method": "post",
       "endpoint": "send/email/single",
       "responses": [
         {
           "uuid": "88a9f955-9277-4d1b-9cc0-bd8e5ad08e98",
-          "body": "{}",
+          "body": "{\n  \"response\": \"Request successfully accepted. Use \\\\\\\"requestUID\\\\\\\" to track it's status.\",\n  \"requestUID\": \"{{faker 'random.alphaNumeric' 4}}-{{faker 'random.alphaNumeric' 4}}-{{faker 'random.alphaNumeric' 4}}-{{faker 'random.alphaNumeric' 4}}-{{faker 'random.alphaNumeric' 4}}-{{faker 'random.alphaNumeric' 4}}\"\n}",
           "latency": 0,
           "statusCode": 200,
-          "label": "",
+          "label": "Request successfully accepted",
           "headers": [],
           "bodyType": "INLINE",
           "filePath": "",
@@ -119,6 +119,105 @@
       ],
       "enabled": true,
       "responseMode": null
+    },
+    {
+      "uuid": "852b68e1-7b8d-4bb9-86a5-ea8eda3136ba",
+      "type": "http",
+      "documentation": "route added for testing to invoke 405 - Method Not Allowed status code",
+      "method": "put",
+      "endpoint": "send/email/single",
+      "responses": [
+        {
+          "uuid": "a8110bfc-2ab4-4786-bfc9-131c690ea18d",
+          "body": "{}",
+          "latency": 0,
+          "statusCode": 405,
+          "label": "",
+          "headers": [
+            {
+              "key": "Allow",
+              "value": "POST"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true
+        }
+      ],
+      "enabled": true,
+      "responseMode": null
+    },
+    {
+      "uuid": "117ccfcd-79fd-4bad-a57b-ca8a5b447ff3",
+      "type": "http",
+      "documentation": "route added for testing to invoke 405 - Method Not Allowed status code",
+      "method": "delete",
+      "endpoint": "send/email/single",
+      "responses": [
+        {
+          "uuid": "567bef11-b88f-4cac-ae81-c998d8d00cb5",
+          "body": "{}",
+          "latency": 0,
+          "statusCode": 405,
+          "label": "",
+          "headers": [
+            {
+              "key": "Allow",
+              "value": "POST"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true
+        }
+      ],
+      "enabled": true,
+      "responseMode": null
+    },
+    {
+      "uuid": "3487c6aa-171e-4a66-964e-ef52105fbb5f",
+      "type": "http",
+      "documentation": "route added for testing to invoke 405 - Method Not Allowed status code",
+      "method": "get",
+      "endpoint": "send/email/single",
+      "responses": [
+        {
+          "uuid": "3f45e895-e7cd-480d-b007-e9ae65a6aad2",
+          "body": "{}",
+          "latency": 0,
+          "statusCode": 405,
+          "label": "",
+          "headers": [
+            {
+              "key": "Allow",
+              "value": "POST"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true
+        }
+      ],
+      "enabled": true,
+      "responseMode": null
     }
   ],
   "rootChildren": [
@@ -137,6 +236,18 @@
     {
       "type": "route",
       "uuid": "777d1380-3802-4a4a-8866-94ddd1d2cf68"
+    },
+    {
+      "type": "route",
+      "uuid": "852b68e1-7b8d-4bb9-86a5-ea8eda3136ba"
+    },
+    {
+      "type": "route",
+      "uuid": "117ccfcd-79fd-4bad-a57b-ca8a5b447ff3"
+    },
+    {
+      "type": "route",
+      "uuid": "3487c6aa-171e-4a66-964e-ef52105fbb5f"
     }
   ],
   "proxyMode": false,

--- a/test/openAPI/features/send_email_single.feature
+++ b/test/openAPI/features/send_email_single.feature
@@ -1,0 +1,30 @@
+@method=POST @endpoint=/send/email/single
+Feature: Send single email
+
+    @smoke @unit @positive
+    Scenario: User successfully sends an email smoke type test
+
+        Given User wants to send a single email
+        When User sends "POST" request with given "abcdef12345" as api_key and required body
+        Then User receives a response from /send/email/single endpoint
+        And The /send/email/single response should be returned in a timely manner 15000ms
+        And The /send/email/single response should have status 200
+        And The /send/email/single response should have content-type: application/json header
+        And The /send/email/single response should match json schema
+
+
+    @unit @negative
+    Scenario Outline: User is unable to send an email due to unallowed method in the request
+
+        Given User wants to send a single email
+        When User sends "<unallowedMethod>" request with given "<api_key>" as api_key and required body
+        Then User receives a response from /send/email/single endpoint
+        And The /send/email/single response should be returned in a timely manner 15000ms
+        And The /send/email/single response should have status 405 - Method not allowed
+        And The /send/email/single response should contain Allow header with POST method which is allowed
+
+        Examples:
+        | unallowedMethod  | api_key     |
+        | GET              | abcdef12345 |
+        | DELETE           | abcdef12345 |
+        | PUT              | abcdef12345 |

--- a/test/openAPI/features/support/helpers/helpers.js
+++ b/test/openAPI/features/support/helpers/helpers.js
@@ -1,4 +1,41 @@
 module.exports = {
   localhost: 'http://localhost:3333/',
   defaultResponseTime: 15000,
+  sendSingleEmailEndpoint: 'send/email/single',
+  contentTypeHeader: {
+    key: 'content-type',
+    value: 'application/json; charset=utf-8',
+  },
+  sendEmailSingleResponseSchema: {
+    type: 'object',
+    properties: {
+      response: { type: 'string' },
+      requestUID: { typep: 'string' },
+    },
+  },
+  sendEmailSingleRequestBody: {
+    callback: {
+      URI: 'https://example.com/callback/emails/requestUID',
+    },
+    senderInfo: {
+      organisationName: 'Example Medical Insitution',
+      organisationRegNr: 'GOV1234567890',
+      onBehalfOfName: 'Example Medical Insitution',
+      onBehalfOfRegNr: 'GOV1234567890',
+      email: 'sender@example.com',
+      replyTo: 'reply-to@example.com',
+      name: 'Example Doctor',
+    },
+    recipientInfo: {
+      email: 'customer@example.com',
+      emailCC: 'customer-cc@example.com',
+      emailBCC: 'customer-bcc@example.com',
+      name: 'Example Customer',
+    },
+    emailContent: {
+      encoding: 'UTF-8',
+      title: 'Example Title Of An Email',
+      content: 'Example Customer',
+    },
+  },
 };

--- a/test/openAPI/features/support/send_email_single.js
+++ b/test/openAPI/features/support/send_email_single.js
@@ -1,0 +1,87 @@
+const chai = require('chai');
+const { spec } = require('pactum');
+const { Given, When, Then, Before, After } = require('@cucumber/cucumber');
+const {
+  localhost,
+  defaultResponseTime,
+  sendSingleEmailEndpoint,
+  contentTypeHeader,
+  sendEmailSingleResponseSchema,
+  sendEmailSingleRequestBody,
+} = require('./helpers/helpers');
+
+chai.use(require('chai-json-schema'));
+
+let specSendEmailSingle;
+
+const baseUrl = localhost + sendSingleEmailEndpoint;
+const endpointTag = { tags: `@endpoint=/${sendSingleEmailEndpoint}` };
+
+Before(endpointTag, () => {
+  specSendEmailSingle = spec();
+});
+
+// Scenario: User successfully sends an email smoke type test
+Given(
+  'User wants to send a single email',
+  () => 'User wants to send a single email'
+);
+
+When(
+  'User sends {string} request with given {string} as api_key and required body',
+  (method, apiKey) =>
+    specSendEmailSingle
+      .withMethod(method)
+      .withPath(baseUrl)
+      .withHeaders('api_key', apiKey)
+      .withHeaders('Accept', 'application/json')
+      .withBody(sendEmailSingleRequestBody)
+);
+
+Then(
+  'User receives a response from \\/send\\/email\\/single endpoint',
+  async () => await specSendEmailSingle.toss()
+);
+
+Then(
+  'The \\/send\\/email\\/single response should be returned in a timely manner 15000ms',
+  () =>
+    specSendEmailSingle
+      .response()
+      .to.have.responseTimeLessThan(defaultResponseTime)
+);
+
+Then('The \\/send\\/email\\/single response should have status 200', () =>
+  specSendEmailSingle.response().to.have.status(200)
+);
+
+Then(
+  'The \\/send\\/email\\/single response should have content-type: application\\/json header',
+  () =>
+    specSendEmailSingle
+      .response()
+      .to.have.headerContains(contentTypeHeader.key, contentTypeHeader.value)
+);
+
+Then('The \\/send\\/email\\/single response should match json schema', () =>
+  chai
+    .expect(specSendEmailSingle._response.json)
+    .to.be.jsonSchema(sendEmailSingleResponseSchema)
+);
+
+// Scenario Outline: User is unable to send an email due to unallowed method in the request
+// Given, When and others Then for this scenario are written in the aforementioned example
+
+Then(
+  'The \\/send\\/email\\/single response should have status 405 - Method not allowed',
+  () => specSendEmailSingle.response().to.have.status(405)
+);
+
+Then(
+  'The \\/send\\/email\\/single response should contain Allow header with POST method which is allowed',
+  () => specSendEmailSingle.response().to.have.headerContains('allow', 'POST')
+);
+
+After(endpointTag, () => {
+  specSendEmailSingle.end();
+});


### PR DESCRIPTION
Added cucumber tests for /send/email/single endpoint

Description:

This should include all the steps that are pointed out in the parent ticket.
Acceptance criteria:
- test is updated
- test match with accepted template

PARENT TICKET: https://govstack-global.atlassian.net/browse/TECH-523
TICKET: https://govstack-global.atlassian.net/browse/TECH-524
